### PR TITLE
Calendar color fix for NP_Calendar.php

### DIFF
--- a/NP_Calendar/NP_Calendar.php
+++ b/NP_Calendar/NP_Calendar.php
@@ -313,8 +313,8 @@ class NP_Calendar extends NucleusPlugin
 				     && $this_month == $month
 				     && $this_year == $year)      $class = 'today';
 				elseif(in_array($mday, $holiday)) $class = 'holiday';
-				elseif($wday == 1)                $class = 'sunday';
-				elseif($wday == 7)                $class = 'saturday';
+				elseif(($startsun == 'yes' && $wday == 1) || ($$startsun != 'yes' && $wday == 7))                $class = 'sunday';
+				elseif(($startsun == 'yes' && $wday == 7) || ($$startsun != 'yes' && $wday == 6))                $class = 'saturday';
 				else                              $class = 'days';
 				$str .= '<td class="' . $class . '">';
 				


### PR DESCRIPTION
Fixed calendar cell colors for Saturday and Sunday when 'startsun' option is set to 'no'.
